### PR TITLE
Added quorum_getPrivatePayload method and test

### DIFF
--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -127,10 +127,10 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
     }
 
     @Override
-    public Request<?, PrivatePayload> quorumGetPrivatePayload(String address) {
+    public Request<?, PrivatePayload> quorumGetPrivatePayload(String hexDigest) {
         return new Request<>(
                 "quorum_getPrivatePayload",
-                Collections.singletonList(address),
+                Collections.singletonList(hexDigest),
                 ID,
                 web3jService,
                 PrivatePayload.class);

--- a/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
+++ b/src/main/java/org/web3j/quorum/JsonRpc2_0Quorum.java
@@ -125,4 +125,14 @@ public class JsonRpc2_0Quorum extends JsonRpc2_0Web3j implements Quorum {
                 web3jService,
                 Voter.class);
     }
+
+    @Override
+    public Request<?, PrivatePayload> quorumGetPrivatePayload(String address) {
+        return new Request<>(
+                "quorum_getPrivatePayload",
+                Collections.singletonList(address),
+                ID,
+                web3jService,
+                PrivatePayload.class);
+    }
 }

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -35,4 +35,6 @@ public interface Quorum extends Web3j {
     Request<?, BlockMaker> quorumIsBlockMaker(String address);
 
     Request<?, Voter> quorumIsVoter(String address);
+
+    Request<?, PrivatePayload> quorumGetPrivatePayload(String address);
 }

--- a/src/main/java/org/web3j/quorum/Quorum.java
+++ b/src/main/java/org/web3j/quorum/Quorum.java
@@ -36,5 +36,5 @@ public interface Quorum extends Web3j {
 
     Request<?, Voter> quorumIsVoter(String address);
 
-    Request<?, PrivatePayload> quorumGetPrivatePayload(String address);
+    Request<?, PrivatePayload> quorumGetPrivatePayload(String hexDigest);
 }

--- a/src/main/java/org/web3j/quorum/methods/response/PrivatePayload.java
+++ b/src/main/java/org/web3j/quorum/methods/response/PrivatePayload.java
@@ -1,0 +1,12 @@
+package org.web3j.quorum.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+/**
+ * quorum_getPrivatePayload
+ */
+public class PrivatePayload extends Response<String> {
+    public String getPrivatePayload() {
+        return getResult();
+    }
+}

--- a/src/test/java/org/web3j/quorum/ResponseTest.java
+++ b/src/test/java/org/web3j/quorum/ResponseTest.java
@@ -86,4 +86,12 @@ public class ResponseTest extends ResponseTester {
         assertTrue(voter.isVoter());
     }
 
+    @Test
+    public void testPrivatePayload() {
+        buildResponse("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0x\"}");
+
+        PrivatePayload privatePayload = deserialiseResponse(PrivatePayload.class);
+        assertThat(privatePayload.getPrivatePayload(), is("0x"));
+    }
+
 }


### PR DESCRIPTION
Enhanced web3j-quorum to support query for private transactions as outlined [here](https://github.com/web3j/quorum/issues/5)