### PR TITLE
Fix for setPrivate to use the RLP decoded payload

### DIFF
--- a/src/main/kotlin/org/web3j/quorum/tx/QuorumTransactionManager.kt
+++ b/src/main/kotlin/org/web3j/quorum/tx/QuorumTransactionManager.kt
@@ -8,14 +8,29 @@ import org.web3j.quorum.tx.util.decode
 import org.web3j.quorum.tx.util.encode
 import org.web3j.quorum.Quorum
 import org.web3j.quorum.enclave.Enclave
+import org.web3j.rlp.RlpDecoder
+import org.web3j.rlp.RlpEncoder
+import org.web3j.rlp.RlpList
+import org.web3j.rlp.RlpString
 import org.web3j.tx.RawTransactionManager
+import org.web3j.tx.TransactionManager
 import org.web3j.utils.Numeric
 import java.math.BigInteger
 
 class QuorumTransactionManager(
         val web3j: Quorum, private val credentials: Credentials, private val publicKey: String,
         var privateFor: List<String> = listOf(),
-        val enclave: Enclave) : RawTransactionManager(web3j, credentials) {
+        val enclave: Enclave,
+        attempts: Int = TransactionManager.DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH,
+        sleepDuration: Long = TransactionManager.DEFAULT_POLLING_FREQUENCY) : RawTransactionManager(web3j, credentials, attempts, sleepDuration.toInt()) {
+
+    // add extra constructor as java does not have optional parameters
+    constructor(web3j: Quorum,
+                credentials: Credentials,
+                publicKey: String,
+                privateFor: List<String> = listOf(),
+                enclave: Enclave) : this(web3j, credentials, publicKey, privateFor, enclave, TransactionManager.DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH, TransactionManager.DEFAULT_POLLING_FREQUENCY){
+    }
 
     override fun sendTransaction(
             gasPrice: BigInteger?, gasLimit: BigInteger?, to: String?, data: String?,
@@ -52,12 +67,33 @@ class QuorumTransactionManager(
         return enclave.sendRawRequest(hexValue, privateFor)
     }
 
+    // If the byte array RLP decodes to a list of size >= 1 containing a list of size >= 3
+    // then find the 3rd element from the last. If the element is a RlpString of size 1 then
+    // it should be the V component from the SignatureData structure -> mark the transaction as private.
+    // If any of of the above checks fails then return the original byte array.
     private fun setPrivate(message: ByteArray): ByteArray {
-        val vOffset = message.size - 67
-        when (message[vOffset]) {
-            28.toByte() -> message[vOffset] = 38
-            else -> message[vOffset] = 37
+        var result = message
+        val rlpWrappingList = RlpDecoder.decode(message)
+        if (rlpWrappingList is RlpList) {
+            if (!rlpWrappingList.values.isEmpty()) {
+                val rlpList = rlpWrappingList.values[0]
+                if (rlpList is RlpList) {
+                    val rlpListSize = rlpList.values.size
+                    if (rlpListSize > 3) {
+                        val vField = rlpList.values[rlpListSize - 3]
+                        if (vField is RlpString) {
+                            if (1 == vField.bytes.size) {
+                                when (vField.bytes[0]) {
+                                    28.toByte() -> vField.bytes[0] = 38
+                                    else -> vField.bytes[0] = 37
+                                }
+                                result = RlpEncoder.encode(rlpList)
+                            }
+                        }
+                    }
+                }
+            }
         }
-        return message
+        return result
     }
 }


### PR DESCRIPTION
Fix for setPrivate to use the RLP decoded payload instead of absolute offset.
Add extra constructor to allow passing attempts and sleepDuration parameters to parent constructor.